### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -42,6 +42,9 @@ func (s *MCPServer) Serve() {
 func (s *MCPServer) registerTools() {
 	insertOne := mcp.NewTool(
 		"weaviate-insert-one",
+		mcp.WithDescription("Insert a single object with its vector embedding into a Weaviate collection. The object can include any properties that match the collection schema. Weaviate automatically generates vector embeddings for the object."),
+		mcp.WithTitleAnnotation("Weaviate: Insert Object"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString(
 			"collection",
 			mcp.Description("Name of the target collection"),
@@ -54,6 +57,9 @@ func (s *MCPServer) registerTools() {
 	)
 	query := mcp.NewTool(
 		"weaviate-query",
+		mcp.WithDescription("Query a Weaviate collection using semantic or hybrid search. Returns matching objects with their properties and similarity scores. Uses Weaviate's vector search capabilities for semantic understanding."),
+		mcp.WithTitleAnnotation("Weaviate: Query"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString(
 			"query",
 			mcp.Description("Query data within Weaviate"),


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

| Tool | Annotation | Rationale |
|------|------------|-----------|
| `weaviate-query` | `readOnlyHint: true` | Searches/queries data, no modifications |
| `weaviate-insert-one` | `destructiveHint: true` | Creates new objects in Weaviate |

Additional changes:
- Added `title` annotations for human-readable display
- Added tool-level descriptions for clarity

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] Server builds successfully (`go build ./...`)
- [x] Using standard mcp-go SDK v0.28.0 annotation API
- [ ] Live verification requires running Weaviate instance

## Before/After

**Before:**
```go
query := mcp.NewTool(
    "weaviate-query",
    mcp.WithString("query", ...),
    // No annotations
)
```

**After:**
```go
query := mcp.NewTool(
    "weaviate-query",
    mcp.WithDescription("Query data within Weaviate using hybrid search"),
    mcp.WithTitleAnnotation("Query Weaviate"),
    mcp.WithReadOnlyHintAnnotation(true),
    mcp.WithString("query", ...),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)